### PR TITLE
`Either Error result` replaced with unwrapped `result`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.tix
 pursuit.json*
 Session.vim
+.psc-ide-port

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![Latest release](http://img.shields.io/bower/v/purescript-sqlite.svg)](https://github.com/Risto-Stevcev/purescript-sqlite/releases)
 
+## Installation
+
+```
+bower install purescript-sqlite
+
+npm install sqlite3
+```
 
 ## Example
 

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
     "purescript-homogeneous-objects": "^3.0.0",
     "purescript-transformers": "^2.2.0",
     "purescript-integers": "^2.1.1",
-    "purescript-nullable": "^2.0.0"
+    "purescript-nullable": "^2.0.0",
+    "purescript-maybe": "^2.1.1"
   },
   "devDependencies": {
     "purescript-psci-support": "^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,8 @@
     "purescript-homogeneous-objects": "^3.0.0",
     "purescript-transformers": "^2.2.0",
     "purescript-integers": "^2.1.1",
-    "purescript-nullable": "^2.0.0",
-    "purescript-maybe": "^2.1.1"
+    "purescript-maybe": "^2.1.1",
+    "purescript-undefinable": "^2.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,9 @@
     "purescript-functions": "^2.0.0",
     "purescript-either": "^2.2.1",
     "purescript-homogeneous-objects": "^3.0.0",
-    "purescript-transformers": "^2.2.0"
+    "purescript-transformers": "^2.2.0",
+    "purescript-integers": "^2.1.1",
+    "purescript-nullable": "^2.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^2.0.0",

--- a/src/Sqlite/Core.js
+++ b/src/Sqlite/Core.js
@@ -69,7 +69,7 @@ exports._getOne = function(db, query) {
         error(err);
       }
       else {
-        success(row === undefined ? null : row);
+        success(row);
       }
     });
   }
@@ -149,7 +149,7 @@ exports._stmtGetOne = function(stmt, params) {
         error(err);
       }
       else {
-        success(row === undefined ? null : row);
+        success(row);
       }
     });
   }

--- a/src/Sqlite/Core.js
+++ b/src/Sqlite/Core.js
@@ -15,54 +15,120 @@ exports._setVerbose = function() {
   sqlite3.verbose()
 }
 
-exports._connect = function(filename, mode, cached) {
-  return function(success, error) {
-    switch (mode.constructor.name) {
-      case 'ReadOnly':
-        var fileMode = sqlite3.OPEN_READONLY
-        break;
-      case 'ReadWrite':
-        var fileMode = sqlite3.OPEN_READWRITE
-        break;
-      case 'Create':
-        var fileMode = sqlite3.OPEN_CREATE
-        break;
-      case 'ReadOnlyCreate':
-        var fileMode = sqlite3.OPEN_READONLY | sqlite3.OPEN_CREATE
-        break;
-      case 'ReadWriteCreate':
-        var fileMode = sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
-        break;
-      default:
-        var fileMode = sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
-    }
+exports._OPEN_READONLY = sqlite3.OPEN_READONLY;
+exports._OPEN_READWRITE = sqlite3.OPEN_READWRITE;
+exports._OPEN_CREATE = sqlite3.OPEN_CREATE;
 
-    if (cached === true)
-      var sqliteDb = sqlite3.cached.Database;
-    else
-      var sqliteDb = sqlite3.Database;
+exports._connect = function(filename, mode, cached, errback, callback) {
+  return function() {
+    var Database = cached ? sqlite3.cached.Database : sqlite3.Database;
 
-    var db = new sqliteDb(filename, fileMode, function(err) {
-      if (err) {
-        error(err);
-      }
-      else {
-        success(db);
-      }
+    var db = new Database(filename, mode, function(err) {
+      if (err) return errback(err)();
+      callback(db)();
     });
   }
 }
 
-exports._close = function(db) {
-  return function(success, error) {
+exports._close = function(db, errback, callback) {
+  return function() {
     db.close(function(err) {
-      if (err)
-        error(err);
-      else
-        success({});
+      if (err) return errback(err)();
+      callback();
     });
   }
 }
+
+exports._run = function(db, query, errback, callback) {
+  return function() {
+    db.run(query, function(err) {
+      if (err) return errback(err)();
+
+      var lastID = this.lastID; // Only for INSERT
+      var changes = this.changes; // Only for UPDATE or DELETE
+      callback({ lastID: lastID, changes: changes })();
+    });
+  }
+}
+
+exports._getOne = function(db, query, errback, callback) {
+  return function() {
+    db.get(query, function(err, row) {
+      if (err) return errback(err)();
+      callback(row === undefined ? null : row)();
+    });
+  }
+}
+
+exports._get = function(db, query, errback, callback) {
+  return function() {
+    db.all(query, function(err, rows) {
+      if (err) return errback(err)();
+      callback(rows)();
+    });
+  }
+}
+
+
+exports._stmtPrepare = function(db, query, errback, callback) {
+  return function() {
+    var statement = db.prepare(query, function(err) {
+      if (err) return errback(err)();
+      callback(statement)();
+    });
+  }
+}
+
+exports._stmtBind = function(stmt, params, errback, callback) {
+  return function() {
+    stmt.bind(params, function(err) {
+      if (err) return errback(err)();
+      callback();
+    });
+  }
+}
+
+exports._stmtReset = function(stmt, callback) {
+  return function() {
+    stmt.reset(callback);
+  }
+}
+
+exports._stmtFinalize = function(stmt, callback) {
+  return function() {
+    stmt.finalize(callback);
+  }
+}
+
+exports._stmtRun = function(stmt, params, errback, callback) {
+  return function() {
+    stmt.run(sqlParamsToObj(params), function(err) {
+      if (err) return errback(err)();
+      var lastID = this.lastID; // Only for INSERT
+      var changes = this.changes; // Only for UPDATE or DELETE
+      callback({ lastID: lastID, changes: changes })();
+    });
+  }
+}
+
+exports._stmtGetOne = function(stmt, params, errback, callback) {
+  return function() {
+    stmt.get(params, function(err, row) {
+      if (err) return errback(err)();
+      callback(row === undefined ? null : row)();
+    });
+  }
+}
+
+exports._stmtGet = function(stmt, params, errback, callback) {
+  return function() {
+    stmt.all(params, function(err, rows) {
+      if (err) return errback(err)();
+      callback(rows)();
+    });
+  }
+}
+
 
 exports._dbListener = function(fn) {
   return function(result) {
@@ -80,111 +146,5 @@ exports._listen = function(db, eventType, callback) {
   return function() {
     db.on(eventType, callback);
     return {};
-  }
-}
-
-exports._run = function(db, query) {
-  return function(success, error) {
-    db.run(query, function(err) {
-      if (err)
-        error(err);
-      else
-        success({});
-    });
-  }
-}
-
-exports._get = function(db, query) {
-  return function(success, error) {
-    db.all(query, function(err, rows) {
-      if (err)
-        error(err);
-      else
-        success(rows);
-    });
-  }
-}
-
-exports._getOne = function(db, query) {
-  return function(success, error) {
-    db.get(query, function(err, rows) {
-      if (err)
-        error(err);
-      else
-        success(rows);
-    });
-  }
-}
-
-exports._stmtPrepare = function(db, query) {
-  return function(success, error) {
-    var statement = db.prepare(query, function(err) {
-      if (err)
-        error(err);
-      else
-        success(statement);
-    });
-  }
-}
-
-exports._stmtBind = function(stmt, params) {
-  return function(success, error) {
-    stmt.bind(params, function(err) {
-      if (err)
-        error(err);
-      else
-        success({});
-    });
-  }
-}
-
-exports._stmtReset = function(stmt) {
-  return function(success, error) {
-    var newStmt = stmt.reset(function() {
-      success(newStmt);
-    });
-  }
-}
-
-exports._stmtFinalize = function(stmt) {
-  return function(success, error) {
-    stmt.finalize(function() {
-      success({});
-    });
-  }
-}
-
-
-exports._stmtRun = function(stmt, params) {
-  return function(success, error) {
-    stmt.run(sqlParamsToObj(params), function(err) {
-      if (err)
-        error(err);
-      else
-        success({});
-    });
-  }
-}
-
-
-exports._stmtGet = function(stmt, params) {
-  return function(success, error) {
-    stmt.all(params, function(err, rows) {
-      if (err)
-        error(err);
-      else
-        success(rows);
-    });
-  }
-}
-
-exports._stmtGetOne = function(stmt, params) {
-  return function(success, error) {
-    stmt.get(params, function(err, row) {
-      if (err)
-        error(err);
-      else
-        success(row);
-    });
   }
 }

--- a/src/Sqlite/Core.js
+++ b/src/Sqlite/Core.js
@@ -24,8 +24,12 @@ exports._connect = function(filename, mode, cached) {
     var Database = cached ? sqlite3.cached.Database : sqlite3.Database;
 
     var db = new Database(filename, mode, function(err) {
-      if (err) return error(err);
-      success(db);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(db);
+      }
     });
   }
 }
@@ -33,8 +37,12 @@ exports._connect = function(filename, mode, cached) {
 exports._close = function(db) {
   return function(success, error) {
     db.close(function(err) {
-      if (err) return error(err);
-      success();
+      if (err) {
+        error(err);
+      }
+      else {
+        success();
+      }
     });
   }
 }
@@ -42,11 +50,14 @@ exports._close = function(db) {
 exports._run = function(db, query) {
   return function(success, error) {
     db.run(query, function(err) {
-      if (err) return error(err);
-
-      var lastID = this.lastID; // Only for INSERT
-      var changes = this.changes; // Only for UPDATE or DELETE
-      success({ lastID: lastID, changes: changes });
+      if (err) {
+        error(err);
+      }
+      else {
+        var lastID = this.lastID; // Only for INSERT
+        var changes = this.changes; // Only for UPDATE or DELETE
+        success({ lastID: lastID, changes: changes });
+      }
     });
   }
 }
@@ -54,8 +65,12 @@ exports._run = function(db, query) {
 exports._getOne = function(db, query) {
   return function(success, error) {
     db.get(query, function(err, row) {
-      if (err) return error(err);
-      success(row === undefined ? null : row);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(row === undefined ? null : row);
+      }
     });
   }
 }
@@ -63,8 +78,12 @@ exports._getOne = function(db, query) {
 exports._get = function(db, query) {
   return function(success, error) {
     db.all(query, function(err, rows) {
-      if (err) return error(err);
-      success(rows);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(rows);
+      }
     });
   }
 }
@@ -73,8 +92,12 @@ exports._get = function(db, query) {
 exports._stmtPrepare = function(db, query) {
   return function(success, error) {
     var statement = db.prepare(query, function(err) {
-      if (err) return error(err);
-      success(statement);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(statement);
+      }
     });
   }
 }
@@ -82,8 +105,12 @@ exports._stmtPrepare = function(db, query) {
 exports._stmtBind = function(stmt, params) {
   return function(success, error) {
     stmt.bind(sqlParamsToObj(params), function(err) {
-      if (err) return error(err);
-      success();
+      if (err) {
+        error(err);
+      }
+      else {
+        success();
+      }
     });
   }
 }
@@ -103,10 +130,14 @@ exports._stmtFinalize = function(stmt) {
 exports._stmtRun = function(stmt, params) {
   return function(success, error) {
     stmt.run(sqlParamsToObj(params), function(err) {
-      if (err) return error(err);
-      var lastID = this.lastID; // Only for INSERT
-      var changes = this.changes; // Only for UPDATE or DELETE
-      success({ lastID: lastID, changes: changes });
+      if (err) {
+        error(err);
+      }
+      else {
+        var lastID = this.lastID; // Only for INSERT
+        var changes = this.changes; // Only for UPDATE or DELETE
+        success({ lastID: lastID, changes: changes });
+      }
     });
   }
 }
@@ -114,8 +145,12 @@ exports._stmtRun = function(stmt, params) {
 exports._stmtGetOne = function(stmt, params) {
   return function(success, error) {
     stmt.get(sqlParamsToObj(params), function(err, row) {
-      if (err) return error(err);
-      success(row === undefined ? null : row);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(row === undefined ? null : row);
+      }
     });
   }
 }
@@ -123,8 +158,12 @@ exports._stmtGetOne = function(stmt, params) {
 exports._stmtGet = function(stmt, params) {
   return function(success, error) {
     stmt.all(sqlParamsToObj(params), function(err, rows) {
-      if (err) return error(err);
-      success(rows);
+      if (err) {
+        error(err);
+      }
+      else {
+        success(rows);
+      }
     });
   }
 }

--- a/src/Sqlite/Core.js
+++ b/src/Sqlite/Core.js
@@ -19,112 +19,112 @@ exports._OPEN_READONLY = sqlite3.OPEN_READONLY;
 exports._OPEN_READWRITE = sqlite3.OPEN_READWRITE;
 exports._OPEN_CREATE = sqlite3.OPEN_CREATE;
 
-exports._connect = function(filename, mode, cached, errback, callback) {
-  return function() {
+exports._connect = function(filename, mode, cached) {
+  return function(success, error) {
     var Database = cached ? sqlite3.cached.Database : sqlite3.Database;
 
     var db = new Database(filename, mode, function(err) {
-      if (err) return errback(err)();
-      callback(db)();
+      if (err) return error(err);
+      success(db);
     });
   }
 }
 
-exports._close = function(db, errback, callback) {
-  return function() {
+exports._close = function(db) {
+  return function(success, error) {
     db.close(function(err) {
-      if (err) return errback(err)();
-      callback();
+      if (err) return error(err);
+      success();
     });
   }
 }
 
-exports._run = function(db, query, errback, callback) {
-  return function() {
+exports._run = function(db, query) {
+  return function(success, error) {
     db.run(query, function(err) {
-      if (err) return errback(err)();
+      if (err) return error(err);
 
       var lastID = this.lastID; // Only for INSERT
       var changes = this.changes; // Only for UPDATE or DELETE
-      callback({ lastID: lastID, changes: changes })();
+      success({ lastID: lastID, changes: changes });
     });
   }
 }
 
-exports._getOne = function(db, query, errback, callback) {
-  return function() {
+exports._getOne = function(db, query) {
+  return function(success, error) {
     db.get(query, function(err, row) {
-      if (err) return errback(err)();
-      callback(row === undefined ? null : row)();
+      if (err) return error(err);
+      success(row === undefined ? null : row);
     });
   }
 }
 
-exports._get = function(db, query, errback, callback) {
-  return function() {
+exports._get = function(db, query) {
+  return function(success, error) {
     db.all(query, function(err, rows) {
-      if (err) return errback(err)();
-      callback(rows)();
+      if (err) return error(err);
+      success(rows);
     });
   }
 }
 
 
-exports._stmtPrepare = function(db, query, errback, callback) {
-  return function() {
+exports._stmtPrepare = function(db, query) {
+  return function(success, error) {
     var statement = db.prepare(query, function(err) {
-      if (err) return errback(err)();
-      callback(statement)();
+      if (err) return error(err);
+      success(statement);
     });
   }
 }
 
-exports._stmtBind = function(stmt, params, errback, callback) {
-  return function() {
-    stmt.bind(params, function(err) {
-      if (err) return errback(err)();
-      callback();
+exports._stmtBind = function(stmt, params) {
+  return function(success, error) {
+    stmt.bind(sqlParamsToObj(params), function(err) {
+      if (err) return error(err);
+      success();
     });
   }
 }
 
-exports._stmtReset = function(stmt, callback) {
-  return function() {
-    stmt.reset(callback);
+exports._stmtReset = function(stmt) {
+  return function(success, error) {
+    stmt.reset(success);
   }
 }
 
-exports._stmtFinalize = function(stmt, callback) {
-  return function() {
-    stmt.finalize(callback);
+exports._stmtFinalize = function(stmt) {
+  return function(success, error) {
+    stmt.finalize(success);
   }
 }
 
-exports._stmtRun = function(stmt, params, errback, callback) {
-  return function() {
+exports._stmtRun = function(stmt, params) {
+  return function(success, error) {
     stmt.run(sqlParamsToObj(params), function(err) {
-      if (err) return errback(err)();
+      if (err) return error(err);
       var lastID = this.lastID; // Only for INSERT
       var changes = this.changes; // Only for UPDATE or DELETE
-      callback({ lastID: lastID, changes: changes })();
+      success({ lastID: lastID, changes: changes });
     });
   }
 }
 
-exports._stmtGetOne = function(stmt, params, errback, callback) {
-  return function() {
-    stmt.get(params, function(err, row) {
-      if (err) return errback(err)();
-      callback(row === undefined ? null : row)();
+exports._stmtGetOne = function(stmt, params) {
+  return function(success, error) {
+    stmt.get(sqlParamsToObj(params), function(err, row) {
+      if (err) return error(err);
+      success(row === undefined ? null : row);
     });
   }
 }
 
-exports._stmtGet = function(stmt, params, errback, callback) {
-  return function() {
-    stmt.all(params, function(err, rows) {
-      if (err) return errback(err)();
-      callback(rows)();
+exports._stmtGet = function(stmt, params) {
+  return function(success, error) {
+    stmt.all(sqlParamsToObj(params), function(err, rows) {
+      if (err) return error(err);
+      success(rows);
     });
   }
 }

--- a/src/Sqlite/Core.purs
+++ b/src/Sqlite/Core.purs
@@ -1,19 +1,36 @@
 module Sqlite.Core where
 
-import Prelude (class Show, Unit, pure, bind, show, ($))
-import Control.Monad.Aff (Aff, attempt)
+import Prelude
+import Data.Int.Bits as Bits
+import Control.Monad.Aff (Aff, makeAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (Error, error)
+import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except (runExcept)
-import Data.Function.Uncurried (Fn3, Fn2, Fn0, runFn3, runFn2, runFn0, mkFn2)
-import Data.Either (Either(..), either)
-import Data.Tuple (Tuple)
+import Data.Either (either)
 import Data.Foreign (Foreign)
 import Data.Foreign.Class (class IsForeign, read)
+import Data.Function.Uncurried (Fn2, Fn3, Fn4, Fn5, mkFn2, runFn2, runFn3, runFn4, runFn5)
 import Data.HObject.Primitive (class Primitive)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Nullable (Nullable, toMaybe)
+import Data.Traversable (sequence)
+import Data.Tuple (Tuple)
+
+
+foreign import _OPEN_READONLY :: Int
+foreign import _OPEN_READWRITE :: Int
+foreign import _OPEN_CREATE :: Int
 
 -- | The file mode when connection to the database
 data DbMode = ReadOnly | ReadWrite | Create | ReadOnlyCreate | ReadWriteCreate
+
+modeToInt :: DbMode -> Int
+modeToInt ReadOnly = _OPEN_READONLY
+modeToInt ReadWrite = _OPEN_READWRITE
+modeToInt Create = _OPEN_CREATE
+modeToInt ReadOnlyCreate = _OPEN_READONLY `Bits.or` _OPEN_CREATE
+modeToInt ReadWriteCreate = _OPEN_READWRITE `Bits.or` _OPEN_CREATE
 
 -- | Corresponds to a database event
 data DbEvent e a
@@ -46,36 +63,143 @@ instance showSqlParam :: Show SqlParam where
 type SqlParams = Array (Tuple String SqlParam)
 
 type SqlQuery = String
-type SqlRow a  = forall e. IsForeign a => Aff ( sqlite :: SQLITE | e ) (Either Error a)
-type SqlRows a = forall e. IsForeign a => Aff ( sqlite :: SQLITE | e ) (Either Error (Array a))
+type SqlRow  a = forall e. IsForeign a => Aff (sqlite :: SQLITE | e) a
+type SqlRows a = forall e. IsForeign a => Aff (sqlite :: SQLITE | e) (Array a)
 
 
 -- | Sets the debug mode for sqlite to verbose
-setVerbose :: Unit
-setVerbose = runFn0 _setVerbose
+setVerbose :: forall e. Eff (sqlite :: SQLITE | e) Unit
+setVerbose = _setVerbose
 
 
 connect
   :: forall e
    . String
   -> DbMode
-  -> Aff ( sqlite :: SQLITE | e ) DbConnection
-connect filename mode = runFn3 _connect filename mode false
+  -> Aff (sqlite :: SQLITE | e) DbConnection
+connect filename dbMode = makeAff $ runFn5 _connect filename mode false
+  where
+  mode = modeToInt dbMode
 
 -- | Uses sqlite's built-in cache to avoid opening the same database multiple times
 connectCached
   :: forall e
    . String
   -> DbMode
-  -> Aff ( sqlite :: SQLITE | e ) DbConnection
-connectCached filename mode = runFn3 _connect filename mode true
+  -> Aff (sqlite :: SQLITE | e) DbConnection
+connectCached filename dbMode = makeAff $ runFn5 _connect filename mode true
+  where
+  mode = modeToInt dbMode
 
 
 close
   :: forall e
    . DbConnection
   -> Aff (sqlite :: SQLITE | e) Unit
-close = _close
+close db = makeAff _close'
+  where
+  _close' onError onSuccess = runFn3 _close db onError $ onSuccess unit
+
+
+-- | "lastID" result value should be used only for INSERT queries,
+-- | "changes" result value should be used only for UPDATE and DELETE queries.
+type RunResult = { lastID :: Int, changes :: Int }
+
+
+run
+  :: forall e
+   . DbConnection
+  -> SqlQuery
+  -> Aff (sqlite :: SQLITE | e) RunResult
+run db query = makeAff $ runFn4 _run db query
+
+
+readRow :: forall a e. IsForeign a => Foreign -> Aff (sqlite :: SQLITE | e) a
+readRow = read >>> runExcept >>> either (show >>> error >>> throwError) pure
+
+
+getOne
+  :: forall a
+   . DbConnection
+  -> SqlQuery
+  -> SqlRow (Maybe a)
+getOne db query = do
+  row <- toMaybe <$> (makeAff $ runFn4 _getOne db query)
+  maybe (pure Nothing) readRow row
+
+
+get
+  :: forall a
+   . DbConnection
+  -> SqlQuery
+  -> SqlRows a
+get db query = do
+  rows <- makeAff $ runFn4 _get db query
+  sequence $ readRow <$> rows
+
+
+stmtPrepare
+  :: forall e
+   . DbConnection
+  -> SqlQuery
+  -> Aff (sqlite :: SQLITE | e) DbStatement
+stmtPrepare db query = makeAff $ runFn4 _stmtPrepare db query
+
+
+stmtBind
+  :: forall e
+   . DbStatement
+  -> SqlParams
+  -> Aff (sqlite :: SQLITE | e) Unit
+stmtBind db query = makeAff bind
+  where
+  bind onError onSuccess = runFn4 _stmtBind db query onError $ onSuccess unit
+
+
+stmtReset
+  :: forall e
+   . DbStatement
+  -> Aff (sqlite :: SQLITE | e) Unit
+stmtReset stmt = makeAff _stmtReset'
+  where
+  _stmtReset' onError onSuccess = runFn2 _stmtReset stmt $ onSuccess unit
+
+
+stmtFinalize
+  :: forall e
+   . DbStatement
+  -> Aff (sqlite :: SQLITE | e) Unit
+stmtFinalize stmt = makeAff _stmtFinalize'
+  where
+  _stmtFinalize' onError onSuccess = runFn2 _stmtFinalize stmt $ onSuccess unit
+
+
+stmtRun
+  :: forall e
+   . DbStatement
+  -> SqlParams
+  -> Aff ( sqlite :: SQLITE | e ) RunResult
+stmtRun stmt params = makeAff $ runFn4 _stmtRun stmt params
+
+
+stmtGetOne
+  :: forall a
+   . DbStatement
+  -> SqlParams
+  -> SqlRow (Maybe a)
+stmtGetOne stmt query = do
+  row <- toMaybe <$> (makeAff $ runFn4 _stmtGetOne stmt query)
+  maybe (pure Nothing) readRow row
+
+
+stmtGet
+  :: forall a
+   . DbStatement
+  -> SqlParams
+  -> SqlRows a
+stmtGet stmt query = do
+  rows <- makeAff $ runFn4 _stmtGet stmt query
+  sequence $ readRow <$> rows
 
 
 -- | Listener for the database open event
@@ -89,116 +213,6 @@ listen db (Close callback)   = runFn3 _listen db "close"   (_dbListener callback
 listen db (Error callback)   = runFn3 _listen db "error"   (_dbListener callback)
 listen db (Trace callback)   = runFn3 _listen db "trace"   (_dbListener callback)
 listen db (Profile callback) = runFn3 _listen db "profile" (_dbListenerFn2 $ mkFn2 callback)
-
-
-run
-  :: forall e
-   . DbConnection
-  -> SqlQuery
-  -> Aff ( sqlite :: SQLITE | e ) Unit
-run = runFn2 _run
-
-
-get
-  :: forall a
-   . DbConnection
-  -> SqlQuery
-  -> SqlRows a
-get db query = do
-  attempted <- attempt $ runFn2 _get db query
-  pure $ readGet attempted
-
-  where
-    readGet :: Either Error Foreign -> Either Error (Array a)
-    readGet (Left err)   = Left err
-    readGet (Right rows) = either (\err -> Left (error $ show err)) Right $ runExcept (read rows)
-
-
-getOne
-  :: forall a
-   . DbConnection
-  -> SqlQuery
-  -> SqlRow a
-getOne db query = do
-  attempted <- attempt $ runFn2 _getOne db query
-  pure $ readGet attempted
-
-  where
-    readGet :: Either Error Foreign -> Either Error a
-    readGet (Left err)   = Left err
-    readGet (Right row) = either (\err -> Left (error $ show err)) Right $ runExcept (read row)
-
-
-
-
-stmtPrepare
-  :: forall e
-   . DbConnection
-  -> SqlQuery
-  -> Aff ( sqlite :: SQLITE | e ) DbStatement
-stmtPrepare = runFn2 _stmtPrepare
-
-
-stmtBind
-  :: forall e
-   . DbStatement
-  -> SqlParams
-  -> Aff ( sqlite :: SQLITE | e ) Unit
-stmtBind = runFn2 _stmtBind
-
-
-stmtReset
-  :: forall e
-   . DbStatement
-  -> Aff ( sqlite :: SQLITE | e ) DbStatement
-stmtReset = _stmtReset
-
-
-stmtFinalize
-  :: forall e
-   . DbStatement
-  -> Aff ( sqlite :: SQLITE | e ) Unit
-stmtFinalize = _stmtFinalize
-
-
-stmtRun
-  :: forall e
-   . DbStatement
-  -> SqlParams
-  -> Aff ( sqlite :: SQLITE | e ) Unit
-stmtRun = runFn2 _stmtRun
-
-
-stmtGet
-  :: forall a
-   . DbStatement
-  -> SqlParams
-  -> SqlRows a
-stmtGet stmt query = do
-  attempted <- attempt $ runFn2 _stmtGet stmt query
-  pure $ readStmt attempted
-
-  where
-    readStmt :: Either Error Foreign -> Either Error (Array a)
-    readStmt (Left err)   = Left err
-    readStmt (Right rows) = either (\err -> Left (error $ show err)) Right $ runExcept (read rows)
-
-
-stmtGetOne
-  :: forall a
-   . DbStatement
-  -> SqlParams
-  -> SqlRow a
-stmtGetOne stmt query = do
-  attempted <- attempt $ runFn2 _stmtGetOne stmt query
-  pure $ readStmt attempted
-
-  where
-    readStmt :: Either Error Foreign -> Either Error a
-    readStmt (Left err)  = Left err
-    readStmt (Right row) = either (\err -> Left (error $ show err)) Right $ runExcept (read row)
-
-
 
 
 foreign import data DbStatement :: *
@@ -224,20 +238,113 @@ foreign import _dbListenerFn2
    . (Fn2 a b (Eff e c))
   -> DbListener e
 
-foreign import _setVerbose :: Fn0 Unit
+foreign import _setVerbose :: forall e. Eff (sqlite :: SQLITE | e) Unit
 
 foreign import _connect
   :: forall e
-   . Fn3
+   . Fn5
      String
-     DbMode
+     Int
      Boolean
-     (Aff ( sqlite :: SQLITE | e ) DbConnection)
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (DbConnection -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
 
 foreign import _close
   :: forall e
-   . DbConnection
-  -> (Aff ( sqlite :: SQLITE | e ) Unit)
+   . Fn3
+     DbConnection
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _run
+  :: forall e
+   . Fn4
+     DbConnection
+     SqlQuery
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (RunResult -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _getOne
+  :: forall e
+   . Fn4
+     DbConnection
+     SqlQuery
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Nullable Foreign -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff ( sqlite :: SQLITE | e ) Unit)
+
+foreign import _get
+  :: forall e
+   . Fn4
+     DbConnection
+     SqlQuery
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Array Foreign -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff ( sqlite :: SQLITE | e ) Unit)
+
+
+foreign import _stmtPrepare
+  :: forall e
+   . Fn4
+     DbConnection
+     SqlQuery
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (DbStatement -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtBind
+  :: forall e
+   . Fn4
+     DbStatement
+     SqlParams
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtReset
+  :: forall e
+   . Fn2
+     DbStatement
+     (Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtFinalize
+  :: forall e
+   . Fn2
+     DbStatement
+     (Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtRun
+  :: forall e
+   . Fn4
+     DbStatement
+     SqlParams
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (RunResult -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtGetOne
+  :: forall e
+   . Fn4
+     DbStatement
+     SqlParams
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Nullable Foreign -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
+foreign import _stmtGet
+  :: forall e
+   . Fn4
+     DbStatement
+     SqlParams
+     (Error -> Eff (sqlite :: SQLITE | e) Unit)
+     (Array Foreign -> Eff (sqlite :: SQLITE | e) Unit)
+     (Eff (sqlite :: SQLITE | e) Unit)
+
 
 foreign import _listen
   :: forall e a
@@ -246,69 +353,3 @@ foreign import _listen
      String
      (DbListener e)
      (Eff e a)
-
-foreign import _run
-  :: forall e
-   . Fn2
-     DbConnection
-     SqlQuery
-     (Aff ( sqlite :: SQLITE | e ) Unit)
-
-foreign import _get
-  :: forall e
-   . Fn2
-     DbConnection
-     SqlQuery
-     (Aff ( sqlite :: SQLITE | e ) Foreign)
-
-foreign import _getOne
-  :: forall e
-   . Fn2
-     DbConnection
-     SqlQuery
-     (Aff ( sqlite :: SQLITE | e ) Foreign)
-
-foreign import _stmtPrepare
-  :: forall e
-   . Fn2
-     DbConnection
-     SqlQuery
-     (Aff ( sqlite :: SQLITE | e ) DbStatement)
-
-foreign import _stmtBind
-  :: forall e
-   . Fn2
-     DbStatement
-     SqlParams
-     (Aff ( sqlite :: SQLITE | e ) Unit)
-
-foreign import _stmtReset
-  :: forall e
-   . DbStatement
-  -> Aff ( sqlite :: SQLITE | e ) DbStatement
-
-foreign import _stmtFinalize
-  :: forall e
-   . DbStatement
-  -> Aff ( sqlite :: SQLITE | e ) Unit
-
-foreign import _stmtRun
-  :: forall e
-   . Fn2
-     DbStatement
-     SqlParams
-     (Aff ( sqlite :: SQLITE | e ) Unit)
-
-foreign import _stmtGet
-  :: forall e
-   . Fn2
-     DbStatement
-     SqlParams
-     (Aff ( sqlite :: SQLITE | e ) Foreign)
-
-foreign import _stmtGetOne
-  :: forall e
-   . Fn2
-     DbStatement
-     SqlParams
-     (Aff ( sqlite :: SQLITE | e ) Foreign)

--- a/src/Sqlite/Core.purs
+++ b/src/Sqlite/Core.purs
@@ -13,7 +13,7 @@ import Data.Foreign.Class (class IsForeign, read)
 import Data.Function.Uncurried (Fn2, Fn3, mkFn2, runFn2, runFn3)
 import Data.HObject.Primitive (class Primitive)
 import Data.Maybe (Maybe(..), maybe)
-import Data.Nullable (Nullable, toMaybe)
+import Data.Undefinable (Undefinable, toMaybe)
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple)
 
@@ -257,7 +257,7 @@ foreign import _getOne
    . Fn2
      DbConnection
      SqlQuery
-     (Aff (sqlite :: SQLITE | e) (Nullable Foreign))
+     (Aff (sqlite :: SQLITE | e) (Undefinable Foreign))
 
 foreign import _get
   :: forall e
@@ -303,7 +303,7 @@ foreign import _stmtGetOne
    . Fn2
      DbStatement
      SqlParams
-     (Aff (sqlite :: SQLITE | e) (Nullable Foreign))
+     (Aff (sqlite :: SQLITE | e) (Undefinable Foreign))
 
 foreign import _stmtGet
   :: forall e

--- a/src/Sqlite/Trans.purs
+++ b/src/Sqlite/Trans.purs
@@ -9,7 +9,7 @@ import Data.Foreign.Class (class IsForeign)
 import Data.Maybe (Maybe)
 import Prelude (Unit, bind, pure, ($))
 
-type SqlRowT a  = forall e. IsForeign a => ExceptT Error (Aff ( sqlite :: SQLITE | e )) a
+type SqlRowT  a = forall e. IsForeign a => ExceptT Error (Aff ( sqlite :: SQLITE | e )) (Maybe a)
 type SqlRowsT a = forall e. IsForeign a => ExceptT Error (Aff ( sqlite :: SQLITE | e )) (Array a)
 
 

--- a/test/Sqlite/Core.purs
+++ b/test/Sqlite/Core.purs
@@ -1,21 +1,19 @@
 module Test.Sqlite.Core where
 
-import Prelude (class Eq, Unit, unit, pure, bind, map, show, const, id, (==), ($), (>>=))
 import Control.Monad.Aff (liftEff', launchAff, attempt)
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff, forE)
-import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION, message)
+import Data.Either (Either(..), isLeft)
+import Data.Foreign.Class (class IsForeign, readProp)
+import Data.HObject.Primitive ((/^\))
+import Prelude (class Eq, Unit, unit, pure, bind, map, show, (==), ($))
+import Sqlite.Core (SqlRows, SQLITE, DbConnection, DbEvent(..), DbMode(..), connect, listen, close, get, stmtFinalize, stmtRun, stmtPrepare, run)
 import Test.Unit (test, suite)
-import Test.Unit.Main (runTest)
 import Test.Unit.Assert (assert)
 import Test.Unit.Console (TESTOUTPUT)
-import Data.Either (Either(..), either, isLeft)
-import Data.Foreign.Class (class IsForeign, readProp)
-import Data.Tuple.Nested ((/\))
-import Data.HObject.Primitive ((/^\))
-import Sqlite.Core ( SqlRows, SQLITE, DbConnection, DbEvent(..), DbMode(..), setVerbose, connect
-                   , listen, close, get, stmtFinalize, stmtRun, stmtPrepare, run )
+import Test.Unit.Main (runTest)
 
 
 instance loremIsForeign :: IsForeign Lorem where
@@ -60,7 +58,7 @@ main = runTest do
       stmtFinalize stmt
 
       rows <- get db "SELECT * from lorem" :: SqlRows Lorem
-      assert "Rows do not match expected output" $ (either (const []) id rows) == map (\x -> Lorem {info: show x}) [0,1,2,3,4,5,6,7,8,9]
+      assert "Rows do not match expected output" $ rows == map (\x -> Lorem {info: show x}) [0,1,2,3,4,5,6,7,8,9]
 
       close db
 
@@ -73,4 +71,7 @@ main = runTest do
         Left err -> assert "Db error object has the wrong message" $ (message err) == "SQLITE_CANTOPEN: unable to open database file"
 
     test "setVerbose" do
-      assert "Set execution mode to verbose failed" $ setVerbose == unit
+      -- setVerbose call can't fail
+      -- This test should somehow check stacktrace
+      -- of a failed sqlite method call
+      pure unit


### PR DESCRIPTION
Main changes:
- Queries now return the value itself instead of Either. Errors are thrown inside Aff and can be resolved during the `runAff` call.
- `run` returns `{ lastID, changes }`.

Minor changes:
- Foreign code refactored, `Aff`-functions are created explicitly using `makeAff`.